### PR TITLE
Allow overriding jquery when instantiating shutterbug

### DIFF
--- a/lib/shutterbug/shutterbug.js
+++ b/lib/shutterbug/shutterbug.js
@@ -1,5 +1,6 @@
 /*global $ */
 (function(){
+  var $ = window.$;
 
   var getBaseUrl = function() {
     var base = window.location.href;
@@ -95,7 +96,16 @@
     destination.postMessage(JSON.stringify(message),"*");
   };
 
-  window.Shutterbug = function(selector,imgDst,callback,id) {
+  window.Shutterbug = function(selector,imgDst,callback,id,jQuery) {
+    if (typeof(jQuery) != "undefined" && jQuery != null) {
+      $ = jQuery;
+    }
+    // If we still don't have a valid jQuery, try setting it from the global jQuery default.
+    // This can happen if shutterbug.js is included before jquery.js
+    if ((typeof($) == "undefined" || $ == null) && typeof(window.$) != "undefined" && window.$ != null) {
+      $ = window.$;
+    }
+
     var shutterbugInstance = {
       element: selector,
       imgDst: imgDst,


### PR DESCRIPTION
This is useful for older Rails apps where $ actually refers to Prototype
and not jQuery.
