### PR TITLE
Emit saycheese, asyouwere events. 

### DIFF
--- a/lib/shutterbug/handlers/shutterbug.js
+++ b/lib/shutterbug/handlers/shutterbug.js
@@ -23,6 +23,8 @@
   var getHtmlFragment = function() {
     var $element = $(this.element);
 
+    $element.trigger('shutterbug-saycheese');
+
     var css     = $('<div>').append($('link[rel="stylesheet"]').clone()).append($('style').clone()).html();
     var width   = $element.width();
     var height  = $element.height();
@@ -59,6 +61,9 @@
       height: height,
       base_url: getBaseUrl()
     };
+
+    $element.trigger('shutterbug-asyouwere');
+
     return html_content;
   };
 


### PR DESCRIPTION
In order to allow applications to do any (synchronous) preparation required before they are ready to be snapshotted, this emits a jQuery custom event called 'shutterbug-saycheese' just prior to copying styles, elements, and canvas contents to the document fragment.

After all elements are copied, emits a 'shutterbug-asyouwere' event.

jQuery custom events are used for wide compatibility. Not all browsers support DOM Level 3 custom events.

Fixes #2 for Shutterbug-aware clients if they can re-render their canvas before returning from the 'shutterbug-saycheese' event handler.
