### PR TITLE
Fixed quote encoding issue and removed unneeded XMLSerializer invocation [#98586586]

### DIFF
--- a/lib/shutterbug/phantom_job.rb
+++ b/lib/shutterbug/phantom_job.rb
@@ -50,8 +50,8 @@ module Shutterbug
       <!DOCTYPE html>
       <html>
         <head>
-          <base href='#{@base_url}'>
-          <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+          <base href=\"#{@base_url}\">
+          <meta content=\"text/html;charset=utf-8\" http-equiv=\"Content-Type\">
           <title>content from #{@base_url} #{date}</title>
           #{@css}
         </head>

--- a/lib/shutterbug/rasterize.js
+++ b/lib/shutterbug/rasterize.js
@@ -236,7 +236,6 @@ function getIframeDataUriSrc(page) {
         var iframes = document.getElementsByTagName('iframe'),
             src = [],
             mimeType = "data:text/html,",
-            serializer = new XMLSerializer(),
             iframe, i;
         for (i = 0; i < iframes.length; i++) {
             iframe = iframes.item(i);


### PR DESCRIPTION
Phantom's html entity decoder borks on single quotes when you have an encoded block with single quotes embedded in another encoded block with single quotes.  The decoder will decode correctly up to the first single quote but then will leave the rest of the string encoded.  If the single quotes are changed to double quotes then they are properly encoded within the enclosing block.  For example:

    " encodes to &quot; which then encodes to &amp;quote; when encoded within another block.

I was not able to run this code locally to verify the fix due to setup issues but when I did the following manually the grey screen shown in [the PT bug](https://www.pivotaltracker.com/story/show/98586586) was resolved:

1. Decode each enclosing iframe data url src block until I got to the inner block
2. Change the single quotes inserted by phantom_job.rb to double quotes and then re-encode the block and insert it back into the parent's iframe data url src param
3. Repeat step 2 until I was back at the parent

I've also removed an unneeded use of XMLSerializer() that was a artifact of the initial dev work to fix the svg encoding issue.