### PR TITLE
Remove temporary files created when using S3 storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ And a Procfile which looks like this:
 
 ## Changes ##
 
+* December 3, 2015 – v 0.5.9
+  * S3 storage provider explicitly removes temporary files.
+  
 *  October 6, 2015 – v 0.5.8
   * Add error_trigger handler, to verify exception reporting.
   * Remove Ruby 1.9x travis tests, because of Fog and Net-SSH deps on Ruby 2.0

--- a/lib/shutterbug.rb
+++ b/lib/shutterbug.rb
@@ -1,5 +1,5 @@
 module Shutterbug
-  VERSION = "0.5.8"
+  VERSION = "0.5.9"
   autoload :Rackapp,        "shutterbug/rackapp"
   autoload :Configuration,  "shutterbug/configuration"
   autoload :Storage,        "shutterbug/storage"

--- a/lib/shutterbug/storage/s3_storage.rb
+++ b/lib/shutterbug/storage/s3_storage.rb
@@ -73,9 +73,12 @@ module Shutterbug
 
       def initialize(filename)
         @filename = filename
-        @stream_file = S3Storage.write(filename)
-        @url = @stream_file.public_url
-        unlink(filename)
+        begin
+          @stream_file = S3Storage.write(filename)
+          @url = @stream_file.public_url
+        ensure
+          unlink(filename)
+        end
       end
     end
   end

--- a/lib/shutterbug/storage/s3_storage.rb
+++ b/lib/shutterbug/storage/s3_storage.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 module Shutterbug
   module Storage
     class S3Storage
@@ -64,10 +65,17 @@ module Shutterbug
         self.connection.put_object_url(Configuration.instance.s3_bin, filename, expiry, headers, options)
       end
 
+      def unlink(filename)
+        if File.exists? filename
+          FileUtils.rm(filename)
+        end
+      end
+
       def initialize(filename)
         @filename = filename
         @stream_file = S3Storage.write(filename)
         @url = @stream_file.public_url
+        unlink(filename)
       end
     end
   end


### PR DESCRIPTION
@scytacki  please review if you get a chance.

An attempt to prevent /tmp filesystem from getting filled.
